### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:latest
+FROM ruby:2.3
 RUN apt-get update -qq && apt-get install -y build-essential nodejs
 
 RUN mkdir /app


### PR DESCRIPTION
Breaks on current `ruby:latest`. Deducing that 'latest' at time of creation was `ruby:2.3` image